### PR TITLE
Fix RBF nsequence: canonical value, all inputs

### DIFF
--- a/lib/src/bitcoin/script/op_code/constant.dart
+++ b/lib/src/bitcoin/script/op_code/constant.dart
@@ -253,7 +253,7 @@ class BitcoinOpCodeConst {
   static const List<int> emptyTxSequence = [0x00, 0x00, 0x00, 0x00];
 
   static const List<int> absoluteTimelockSequence = [0xfe, 0xff, 0xff, 0xff];
-  static const List<int> replaceByFeeSequence = [0x01, 0x00, 0x00, 0x00];
+  static const List<int> replaceByFeeSequence = [0xfd, 0xff, 0xff, 0xff];
 
   /// Script version and Bitcoin-related identifiers
   static const int leafVersionTapscript = 0xc0;

--- a/lib/src/transaction_builder/forked_transaction_builder.dart
+++ b/lib/src/transaction_builder/forked_transaction_builder.dart
@@ -264,10 +264,12 @@ that demonstrate the right to spend the bitcoins associated with the correspondi
       });
     }
     final inputs = sortedUtxos.map((e) => e.utxo.toInput()).toList();
-    if (enableRBF && inputs.isNotEmpty) {
-      inputs[0] = inputs[0].copyWith(
-        sequence: BitcoinOpCodeConst.replaceByFeeSequence,
-      );
+    if (enableRBF) {
+      for (int i = 0; i < inputs.length; i++) {
+        inputs[i] = inputs[i].copyWith(
+          sequence: BitcoinOpCodeConst.replaceByFeeSequence,
+        );
+      }
     }
     return (
       List<TxInput>.unmodifiable(inputs),

--- a/lib/src/transaction_builder/transaction_builder.dart
+++ b/lib/src/transaction_builder/transaction_builder.dart
@@ -414,10 +414,12 @@ that demonstrate the right to spend the bitcoins associated with the correspondi
       });
     }
     final inputs = sortedUtxos.map((e) => e.utxo.toInput()).toList();
-    if (enableRBF && inputs.isNotEmpty) {
-      inputs[0] = inputs[0].copyWith(
-        sequence: BitcoinOpCodeConst.replaceByFeeSequence,
-      );
+    if (enableRBF) {
+      for (int i = 0; i < inputs.length; i++) {
+        inputs[i] = inputs[i].copyWith(
+          sequence: BitcoinOpCodeConst.replaceByFeeSequence,
+        );
+      }
     }
     return (
       List<TxInput>.unmodifiable(inputs),


### PR DESCRIPTION
0x01 signals opt-in RBF, but on v2 txs it also sets a BIP-68 relative timelock of 1 block (unintended), and it's an abnormal value that fingerprints the wallet on-chain, harmful in collaborative settings like payjoin. It was also applied only to inputs[0], leaving a mixed [0x01, MAX, …] pattern that fingerprints too.

use the canonical 0xFFFFFFFD (ENABLE_RBF_NO_LOCKTIME) and apply it to every input, in both builders.

ref: https://github.com/payjoin/rust-payjoin/issues/1597

closes #22 