### PR TITLE
Add locktime param to transaction builders

### DIFF
--- a/lib/src/transaction_builder/forked_transaction_builder.dart
+++ b/lib/src/transaction_builder/forked_transaction_builder.dart
@@ -28,6 +28,7 @@ class ForkedTransactionBuilder extends BasedBitcoinTransacationBuilder {
   final String? memo;
   final bool enableRBF;
   final bool isFakeTransaction;
+  final List<int> locktime;
 
   ForkedTransactionBuilder({
     required super.outPuts,
@@ -39,6 +40,7 @@ class ForkedTransactionBuilder extends BasedBitcoinTransacationBuilder {
     this.memo,
     this.enableRBF = false,
     this.isFakeTransaction = false,
+    this.locktime = BitcoinOpCodeConst.defaultTxLocktime,
   }) {
     _validateBuilder();
   }
@@ -492,7 +494,7 @@ be retrieved by anyone who examines the blockchain's history.
     );
 
     /// create new transaction with inputs and outputs and isSegwit transaction or not
-    final transaction = BtcTransaction(inputs: inputs, outputs: outputs);
+    final transaction = BtcTransaction(inputs: inputs, outputs: outputs, locktime: locktime);
     const sighash =
         BitcoinOpCodeConst.sighashAll | BitcoinOpCodeConst.sighashForked;
 
@@ -604,7 +606,7 @@ be retrieved by anyone who examines the blockchain's history.
     );
 
     /// create new transaction with inputs and outputs and isSegwit transaction or not
-    final transaction = BtcTransaction(inputs: inputs, outputs: outputs);
+    final transaction = BtcTransaction(inputs: inputs, outputs: outputs, locktime: locktime);
 
     const sighash =
         BitcoinOpCodeConst.sighashAll | BitcoinOpCodeConst.sighashForked;

--- a/lib/src/transaction_builder/transaction_builder.dart
+++ b/lib/src/transaction_builder/transaction_builder.dart
@@ -28,6 +28,7 @@ class BitcoinTransactionBuilder extends BasedBitcoinTransacationBuilder {
   final String? memo;
   final bool enableRBF;
   final bool isFakeTransaction;
+  final List<int> locktime;
 
   BitcoinTransactionBuilder({
     required super.outPuts,
@@ -39,6 +40,7 @@ class BitcoinTransactionBuilder extends BasedBitcoinTransacationBuilder {
     this.memo,
     this.enableRBF = false,
     this.isFakeTransaction = false,
+    this.locktime = BitcoinOpCodeConst.defaultTxLocktime,
   }) {
     _validateBuilder();
   }
@@ -514,6 +516,7 @@ that demonstrate the right to spend the bitcoins associated with the correspondi
     BtcTransaction transaction = BtcTransaction(
       inputs: inputs,
       outputs: outputs,
+      locktime: locktime,
     );
 
     /// we define empty witnesses. maybe the transaction is segwit and We need this
@@ -715,6 +718,7 @@ that demonstrate the right to spend the bitcoins associated with the correspondi
     BtcTransaction transaction = BtcTransaction(
       inputs: inputs,
       outputs: outputs,
+      locktime: locktime,
     );
 
     /// we define empty witnesses. maybe the transaction is segwit and We need this

--- a/test/transaction_builder_locktime_test.dart
+++ b/test/transaction_builder_locktime_test.dart
@@ -1,0 +1,52 @@
+import 'package:bitcoin_base/bitcoin_base.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BitcoinTransactionBuilder locktime', () {
+    test('defaults to defaultTxLocktime', () {
+      final b = BitcoinTransactionBuilder(
+        outPuts: const [],
+        fee: BigInt.zero,
+        network: BitcoinNetwork.mainnet,
+        utxos: const [],
+      );
+      expect(b.locktime, BitcoinOpCodeConst.defaultTxLocktime);
+    });
+
+    test('stores the provided locktime', () {
+      final lt = [0x50, 0x01, 0xcf, 0x00];
+      final b = BitcoinTransactionBuilder(
+        outPuts: const [],
+        fee: BigInt.zero,
+        network: BitcoinNetwork.mainnet,
+        utxos: const [],
+        locktime: lt,
+      );
+      expect(b.locktime, lt);
+    });
+  });
+
+  group('ForkedTransactionBuilder locktime', () {
+    test('defaults to defaultTxLocktime', () {
+      final b = ForkedTransactionBuilder(
+        outPuts: const [],
+        fee: BigInt.zero,
+        network: BitcoinCashNetwork.mainnet,
+        utxos: const [],
+      );
+      expect(b.locktime, BitcoinOpCodeConst.defaultTxLocktime);
+    });
+
+    test('stores the provided locktime', () {
+      final lt = [0x50, 0x01, 0xcf, 0x00];
+      final b = ForkedTransactionBuilder(
+        outPuts: const [],
+        fee: BigInt.zero,
+        network: BitcoinCashNetwork.mainnet,
+        utxos: const [],
+        locktime: lt,
+      );
+      expect(b.locktime, lt);
+    });
+  });
+}


### PR DESCRIPTION
Closes #23.

`BitcoinTransactionBuilder` and `ForkedTransactionBuilder` never pass a `locktime` to the `BtcTransaction` they build, so every tx is stuck at the default with no way for a caller to set it. This adds an optional `locktime` param (default `BitcoinOpCodeConst.defaultTxLocktime`, so existing behavior is unchanged), threaded into both build paths of each builder. Includes a test.